### PR TITLE
[codex] Streamline room load state

### DIFF
--- a/test/chatShortcut.test.js
+++ b/test/chatShortcut.test.js
@@ -56,6 +56,7 @@ function loadChatPage(overrides = {}) {
   const elements = new Map();
   const documentListeners = {};
   const posts = [];
+  const gets = [];
   const alerts = [];
   const userAttributes = overrides.userAttributes || {
     username: 'test_player',
@@ -112,6 +113,8 @@ function loadChatPage(overrides = {}) {
         if (overrides.postResponse) {
           return Promise.resolve(overrides.postResponse);
         }
+      } else {
+        gets.push(endpoint);
       }
       return Promise.resolve({
         ok: true,
@@ -130,6 +133,14 @@ function loadChatPage(overrides = {}) {
           }
           if (endpoint === '/room-ecology/1/1') {
             return roomEcology;
+          }
+          if (endpoint === '/room-state/1/1') {
+            return {
+              room: roomEcology,
+              messages: [],
+              user: userAttributes,
+              tick: 1
+            };
           }
           return {};
         },
@@ -165,6 +176,7 @@ function loadChatPage(overrides = {}) {
     context,
     getElement,
     alerts,
+    gets,
     posts
   };
 }
@@ -233,6 +245,18 @@ test('chat header combines job and level and moves gold into the right-side stat
     page.getElement('skill-id').title,
     'Dose: Patch someone up by day, poison them by night.\n- Day: heals the target.\n- Night: poisons the target.'
   );
+});
+
+test('chat startup fetches one room state payload', async () => {
+  const page = loadChatPage();
+
+  await flushPromises();
+
+  assert.ok(page.gets.includes('/room-state/1/1'));
+  assert.equal(page.gets.includes('/messages/1/1'), false);
+  assert.equal(page.gets.includes('/room-ecology/1/1'), false);
+  assert.equal(page.gets.includes('/user-attributes'), false);
+  assert.equal(page.gets.includes('/tick'), false);
 });
 
 test('chat renderer colors support, death, attack, and speed result messages', () => {

--- a/test/workerMigration.test.js
+++ b/test/workerMigration.test.js
@@ -217,9 +217,100 @@ test('Daily world event seeding backfills missing hostile rooms for an existing 
   }
 });
 
-test('Chat ticks respawn cleared ambient hostiles after their respawn interval', async () => {
+test('Room and map reads do not seed daily world events', async () => {
   const db = await createMigratedDb();
-  const { ensureDailyWorldEvents, handleAttack, handleChatAction } = await import('../worker/game.mjs');
+  const {
+    getActiveWorldEvents,
+    getRoomEcology
+  } = await import('../worker/game.mjs');
+
+  try {
+    await db.prepare(
+      `INSERT INTO users
+        (username, password, job, health, maxHealth, stamina, maxStamina, speed, strength, intelligence)
+       VALUES ('reader', 'pw', 'Novice', 12, 12, 100, 100, 1, 1, 1)`
+    ).run();
+
+    assert.deepEqual(await getActiveWorldEvents(db, '2026-05-29'), []);
+    await getRoomEcology(db, 'reader', 1, 1, '2026-05-29');
+
+    const eventCount = await db.prepare('SELECT COUNT(*) AS count FROM worldEvents').first();
+    const npcCount = await db.prepare('SELECT COUNT(*) AS count FROM users WHERE isNpc = 1').first();
+
+    assert.equal(eventCount.count, 0);
+    assert.equal(npcCount.count, 0);
+  } finally {
+    await db.close();
+  }
+});
+
+test('NPC presence stays visible while stale player presence expires', async () => {
+  const db = await createMigratedDb();
+  const {
+    getRoomEcology
+  } = await import('../worker/game.mjs');
+
+  try {
+    await db.prepare(
+      `INSERT INTO users
+        (username, password, job, health, maxHealth, stamina, maxStamina, speed, strength, intelligence, isNpc, displayName, npcKind, worldEventId)
+       VALUES
+        ('stale_player', 'pw', 'Novice', 12, 12, 100, 100, 1, 1, 1, 0, NULL, NULL, NULL),
+        ('old_lurker', 'npc', 'Novice', 8, 8, 60, 60, 3, 4, 1, 1, 'Room Lurker', 'ambient_hostile', 'old_event')`
+    ).run();
+    await db.prepare(
+      `INSERT INTO roomPresence
+        (username, roomRow, roomCol, lastSeenTick, worldDay, lastSeenAt)
+       VALUES
+        ('stale_player', 2, 2, 1, '2026-05-29', datetime('now', '-10 minutes')),
+        ('old_lurker', 2, 2, 1, '2026-05-29', datetime('now', '-10 minutes'))`
+    ).run();
+
+    const ecology = await getRoomEcology(db, 'stale_player', 2, 2, '2026-05-29');
+
+    assert.deepEqual(ecology.presence.map(entity => entity.username), ['old_lurker']);
+  } finally {
+    await db.close();
+  }
+});
+
+test('Room state combines room, messages, user, and tick without seeding world events', async () => {
+  const db = await createMigratedDb();
+  const { getRoomState } = await import('../worker/game.mjs');
+
+  try {
+    await db.prepare(
+      `INSERT INTO users
+        (username, password, job, health, maxHealth, stamina, maxStamina, speed, strength, intelligence, level, gold, experience)
+       VALUES ('state_player', 'pw', 'Fighter', 12, 12, 100, 100, 3, 4, 2, 1, 7, 9)`
+    ).run();
+    await db.prepare(
+      `INSERT INTO messages (roomRow, roomCol, username, message)
+       VALUES (3, 3, 'state_player', 'hello room')`
+    ).run();
+
+    const state = await getRoomState(db, 'state_player', 3, 3);
+
+    assert.equal(state.tick, 0);
+    assert.equal(state.room.room.row, 3);
+    assert.equal(state.messages.length, 1);
+    assert.equal(state.messages[0].message, 'hello room');
+    assert.equal(state.user.username, 'state_player');
+    assert.equal(state.user.gold, 7);
+    assert.equal(state.user.experience, 9);
+    assert.deepEqual(state.user.achievements, []);
+    assert.deepEqual(state.user.kills, []);
+
+    const eventCount = await db.prepare('SELECT COUNT(*) AS count FROM worldEvents').first();
+    assert.equal(eventCount.count, 0);
+  } finally {
+    await db.close();
+  }
+});
+
+test('Scheduled pulses respawn cleared ambient hostiles after their respawn interval', async () => {
+  const db = await createMigratedDb();
+  const { ensureDailyWorldEvents, handleAttack, runScheduledWorldPulse } = await import('../worker/game.mjs');
   const { getWorldDay } = require('../utils/roomEcology');
   const worldDay = getWorldDay();
 
@@ -257,7 +348,7 @@ test('Chat ticks respawn cleared ambient hostiles after their respawn interval',
       .bind(defeated.lastDefeatedTick + defeated.respawnInterval - 1)
       .run();
 
-    await handleChatAction(db, 'fighter', hostile.roomRow, hostile.roomCol, 'keeping watch');
+    await runScheduledWorldPulse(db);
 
     const respawnedNpc = await db.prepare('SELECT username FROM users WHERE username = ? AND isNpc = 1')
       .bind(hostile.npcUsername)

--- a/worker/game.mjs
+++ b/worker/game.mjs
@@ -577,11 +577,8 @@ export async function getActiveRound(db, row, col, worldDay, tickValue) {
   };
 }
 
-export async function getRoomEcology(db, username, row, col) {
-  const worldDay = getWorldDay();
+export async function getRoomEcology(db, username, row, col, worldDay = getWorldDay()) {
   const tickValue = await getCurrentTickValue(db);
-  await cleanupOldWorldDayData(db, worldDay);
-  await ensureDailyWorldEvents(db, worldDay, tickValue);
   const traces = await dbAll(
     db,
     `SELECT id, roomRow, roomCol, traceType, intensity, attacker, target, createdTick, expiryTick, worldDay, createdAt
@@ -614,6 +611,71 @@ export async function getRoomEcology(db, username, row, col) {
     event,
     description: composeRoomDescription({ row, col, phase, features, traceSummary }),
     ...effectPayload
+  };
+}
+
+export async function getUserState(db, username) {
+  const user = await dbFirst(
+    db,
+    'SELECT username, job, health, maxHealth, stamina, maxStamina, speed, strength, intelligence, level, gold, experience, attributePoints, displayName FROM users WHERE username = ? AND isNpc = 0',
+    [username]
+  );
+  if (!user) {
+    throw new ActionError('User Not Found', 404);
+  }
+
+  const effective = getEffectiveUser(user);
+  const achievements = await dbAll(
+    db,
+    `SELECT achievementType, eventId, worldDay, earnedTick, rewardExperience, rewardGold
+     FROM worldEventAchievements
+     WHERE username = ?
+     ORDER BY earnedTick DESC, id DESC`,
+    [username]
+  );
+  const kills = await dbAll(
+    db,
+    `SELECT defeatedUsername, defeatedName, defeatedKind, defeatedLevel, experienceGained, goldGained, roomRow, roomCol, worldDay, tick, createdAt
+     FROM killHistory
+     WHERE killerUsername = ?
+     ORDER BY id DESC
+     LIMIT 50`,
+    [username]
+  );
+
+  return {
+    ...user,
+    job: effective.job,
+    baseStats: effective.baseStats,
+    jobBonuses: effective.jobBonuses,
+    effectiveStats: {
+      health: effective.health,
+      maxHealth: effective.maxHealth,
+      stamina: effective.stamina,
+      maxStamina: effective.maxStamina,
+      speed: effective.speed,
+      strength: effective.strength,
+      intelligence: effective.intelligence
+    },
+    skill: effective.skill,
+    achievements,
+    kills
+  };
+}
+
+export async function getRoomState(db, username, row, col) {
+  const tick = await getCurrentTickValue(db);
+  const [room, messages, user] = await Promise.all([
+    getRoomEcology(db, username, row, col),
+    getMessages(db, row, col),
+    getUserState(db, username)
+  ]);
+
+  return {
+    room,
+    messages,
+    user,
+    tick
   };
 }
 
@@ -1251,7 +1313,6 @@ export async function advanceGlobalTick(db) {
   await processRoomEffects(db, tickValue);
   await processStatusEffects(db, tickValue);
   await resolveExpiredGamblingRounds(db, tickValue);
-  await ensureDailyWorldEvents(db, getWorldDay(), tickValue);
 
   return {
     tick: tickValue,
@@ -1261,6 +1322,7 @@ export async function advanceGlobalTick(db) {
 
 export async function runScheduledWorldPulse(db) {
   const tick = await advanceGlobalTick(db);
+  await ensureDailyWorldEvents(db, getWorldDay(), tick.tick);
 
   return {
     tick,
@@ -1269,7 +1331,6 @@ export async function runScheduledWorldPulse(db) {
 }
 
 export async function getActiveWorldEvents(db, worldDay = getWorldDay()) {
-  await ensureDailyWorldEvents(db, worldDay);
   return dbAll(
     db,
     `SELECT id, eventType, roomRow AS row, roomCol AS col, status, title, description, rewardExperience, rewardGold

--- a/worker/index.mjs
+++ b/worker/index.mjs
@@ -13,11 +13,12 @@ import {
   JOBS,
   buildStartingStats,
   getCurrentTickValue,
-  getEffectiveUser,
   getMessages,
   getActiveWorldEvents,
   getRoomAccessState,
   getRoomEcology,
+  getRoomState,
+  getUserState,
   handleAttackAction,
   handleChatAction,
   handleJobChangeAction,
@@ -487,50 +488,11 @@ app.get('/user-attributes', async c => {
   if (auth instanceof Response) {
     return auth;
   }
-  const user = await dbFirst(
-    c.env.DB,
-    'SELECT username, job, health, maxHealth, stamina, maxStamina, speed, strength, intelligence, level, gold, experience, attributePoints FROM users WHERE username = ? AND isNpc = 0',
-    [auth.user.username]
-  );
-  if (!user) {
-    return c.json({ error: 'User Not Found' }, 404);
+  try {
+    return c.json(await getUserState(c.env.DB, auth.user.username));
+  } catch (err) {
+    return formError(c, err);
   }
-  const effective = getEffectiveUser(user);
-  const achievements = await dbAll(
-    c.env.DB,
-    `SELECT achievementType, eventId, worldDay, earnedTick, rewardExperience, rewardGold
-     FROM worldEventAchievements
-     WHERE username = ?
-     ORDER BY earnedTick DESC, id DESC`,
-    [auth.user.username]
-  );
-  const kills = await dbAll(
-    c.env.DB,
-    `SELECT defeatedUsername, defeatedName, defeatedKind, defeatedLevel, experienceGained, goldGained, roomRow, roomCol, worldDay, tick, createdAt
-     FROM killHistory
-     WHERE killerUsername = ?
-     ORDER BY id DESC
-     LIMIT 50`,
-    [auth.user.username]
-  );
-  return c.json({
-    ...user,
-    job: effective.job,
-    baseStats: effective.baseStats,
-    jobBonuses: effective.jobBonuses,
-    effectiveStats: {
-      health: effective.health,
-      maxHealth: effective.maxHealth,
-      stamina: effective.stamina,
-      maxStamina: effective.maxStamina,
-      speed: effective.speed,
-      strength: effective.strength,
-      intelligence: effective.intelligence
-    },
-    skill: effective.skill,
-    achievements,
-    kills
-  });
 });
 
 app.get('/tick', async c => c.json({ tick: await getCurrentTickValue(c.env.DB) }));
@@ -559,6 +521,24 @@ app.get('/room-ecology/:row/:col', async c => {
   try {
     const { row, col } = parseCoordinates(c);
     return c.json(await getRoomEcology(c.env.DB, auth.user.username, row, col));
+  } catch (err) {
+    return formError(c, err);
+  }
+});
+
+app.get('/room-state/:row/:col', async c => {
+  const auth = await currentUserOrResponse(c);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  try {
+    const { row, col } = parseCoordinates(c);
+    const roomUse = await ensureRoomUse(c, auth.user, row, col);
+    if (!roomUse.allowed) {
+      throw new ActionError('Inn access required', 403);
+    }
+    return c.json(await getRoomState(c.env.DB, auth.user.username, row, col));
   } catch (err) {
     return formError(c, err);
   }

--- a/worker/static/chat.html
+++ b/worker/static/chat.html
@@ -187,6 +187,15 @@
       return messageElement;
     }
 
+    function renderMessages(data) {
+      const messagesDiv = document.getElementById('messages');
+      messagesDiv.innerHTML = '';
+      data.forEach(msg => {
+        messagesDiv.appendChild(renderMessage(msg));
+      });
+      scrollToBottom();
+    }
+
     function loadMessages() {
       fetch(`/messages/${row}/${col}`)
         .then(response => {
@@ -198,17 +207,44 @@
           }
           return response.json();
         })
-        .then(data => {
-          const messagesDiv = document.getElementById('messages');
-          messagesDiv.innerHTML = '';
-          data.forEach(msg => {
-            messagesDiv.appendChild(renderMessage(msg));
-          });
-          scrollToBottom();
-        })
+        .then(renderMessages)
         .catch(() => {
           document.getElementById('messages').textContent = 'Messages are unavailable in this room right now.';
         });
+    }
+
+    function renderUserAttributes(data) {
+      const attributesDiv = document.getElementById('attributes');
+      const effective = data.effectiveStats || data;
+      currentSkill = data.skill || null;
+      currentJob = data.job || 'Novice';
+      document.getElementById('character-link').textContent = data.displayName || data.username || 'Status';
+      attributesDiv.innerHTML = `
+        <p>${data.job || 'Novice'} ~ Level ${data.level}</p>
+        <p>Health: ${effective.health}/${effective.maxHealth}</p>
+        <p>Stamina: ${effective.stamina}/${effective.maxStamina}</p>
+        <p>Speed: ${effective.speed}</p>
+        <p>Strength: ${effective.strength}</p>
+        <p>Intelligence: ${effective.intelligence}</p>
+      `;
+      document.getElementById('gold').textContent = `Gold: ${data.gold !== undefined ? data.gold : 0}`;
+      const skillSelect = document.getElementById('skill-id');
+      if (skillSelect && currentSkill) {
+        skillSelect.innerHTML = '';
+        const option = document.createElement('option');
+        option.value = currentSkill.id;
+        option.textContent = currentSkill.label;
+        const skillTooltip = getSkillTooltip(currentSkill);
+        option.title = skillTooltip;
+        skillSelect.title = skillTooltip;
+        skillSelect.appendChild(option);
+      }
+      const jobSelect = document.getElementById('job-select');
+      if (jobSelect) {
+        Array.from(jobSelect.options).forEach(option => {
+          option.selected = option.value === currentJob;
+        });
+      }
     }
 
     function loadUserAttributes() {
@@ -219,39 +255,7 @@
           }
           return response.json();
         })
-        .then(data => {
-          const attributesDiv = document.getElementById('attributes');
-          const effective = data.effectiveStats || data;
-          currentSkill = data.skill || null;
-          currentJob = data.job || 'Novice';
-          document.getElementById('character-link').textContent = data.displayName || data.username || 'Status';
-          attributesDiv.innerHTML = `
-            <p>${data.job || 'Novice'} ~ Level ${data.level}</p>
-            <p>Health: ${effective.health}/${effective.maxHealth}</p>
-            <p>Stamina: ${effective.stamina}/${effective.maxStamina}</p>
-            <p>Speed: ${effective.speed}</p>
-            <p>Strength: ${effective.strength}</p>
-            <p>Intelligence: ${effective.intelligence}</p>
-          `;
-          document.getElementById('gold').textContent = `Gold: ${data.gold !== undefined ? data.gold : 0}`;
-          const skillSelect = document.getElementById('skill-id');
-          if (skillSelect && currentSkill) {
-            skillSelect.innerHTML = '';
-            const option = document.createElement('option');
-            option.value = currentSkill.id;
-            option.textContent = currentSkill.label;
-            const skillTooltip = getSkillTooltip(currentSkill);
-            option.title = skillTooltip;
-            skillSelect.title = skillTooltip;
-            skillSelect.appendChild(option);
-          }
-          const jobSelect = document.getElementById('job-select');
-          if (jobSelect) {
-            Array.from(jobSelect.options).forEach(option => {
-              option.selected = option.value === currentJob;
-            });
-          }
-        });
+        .then(renderUserAttributes);
     }
 
     function getSkillTooltip(skill) {
@@ -264,14 +268,17 @@
       return lines.join('\n');
     }
 
+    function renderTick(tickValue) {
+      phase = tickValue % 100 < 50 ? 'Day' : 'Night';
+      document.getElementById('tick').textContent = `Global Tick: ${tickValue}`;
+      document.getElementById('phase').textContent = `Phase: ${phase}`;
+    }
+
     function loadTick() {
       fetch('/tick')
         .then(response => response.json())
         .then(data => {
-          const tickValue = data.tick;
-          phase = tickValue % 100 < 50 ? 'Day' : 'Night';
-          document.getElementById('tick').textContent = `Global Tick: ${tickValue}`;
-          document.getElementById('phase').textContent = `Phase: ${phase}`;
+          renderTick(data.tick);
         });
     }
 
@@ -311,6 +318,41 @@
       return String(description || '').replace(new RegExp(`^Room\\s+${rowValue},\\s*${colValue}\\.\\s*`, 'i'), '');
     }
 
+    function renderRoomEcology(data) {
+      const toolbar = document.getElementById('room-ecology-toolbar');
+      const featureLabels = data.features.map(feature => feature.active === false ? `${feature.label} (dormant)` : feature.label);
+      const traceLabels = data.traceSummary.labels.length > 0 ? data.traceSummary.labels : ['none'];
+      const effectLabels = data.effects && data.effects.length > 0
+        ? data.effects.map(effect => effect.label || effect.type)
+        : ['none'];
+
+      toolbar.innerHTML = '';
+      setParagraph(toolbar, `Room: ${data.room.row}, ${data.room.col}`);
+      setParagraph(toolbar, `Features: ${featureLabels.join(', ')}`);
+      setParagraph(toolbar, `Systems: ${effectLabels.join(', ')}`);
+      setParagraph(toolbar, `Traces: ${traceLabels.join(', ')}`);
+      if (data.stock && data.stock.length > 0) {
+        setParagraph(toolbar, `Stock: ${data.stock.map(item => `${item.name} ${item.price}g`).join(', ')}`);
+      }
+      if (data.commands && data.commands.length > 0) {
+        setParagraph(toolbar, `Commands: ${data.commands.join(', ')}`);
+      }
+      if (data.innAccess && data.innAccess.required) {
+        setParagraph(toolbar, `Inn: ${data.innAccess.paid ? 'paid' : `${data.innAccess.fee}g`}`);
+      }
+      if (data.activeRound) {
+        setParagraph(toolbar, `Dice pool: ${data.activeRound.pool}g, closes in ${data.activeRound.remainingTicks} ticks`);
+      }
+      if (data.event) {
+        setParagraph(toolbar, `Event: ${data.event.title} (${data.event.eventType})`);
+      }
+      const roomDescription = getRoomDescriptionWithoutLocation(data.description, data.room.row, data.room.col);
+      setParagraph(toolbar, `Reset: ${new Date(data.nextResetAt).toUTCString()} ${roomDescription}`);
+      setPresenceParagraph(toolbar, data.presence || []);
+      const isGuild = data.effects && data.effects.some(effect => effect.type === 'guild');
+      document.getElementById('job-controls').style.display = isGuild ? 'flex' : 'none';
+    }
+
     function loadRoomEcology() {
       fetch(`/room-ecology/${row}/${col}`)
         .then(response => {
@@ -319,39 +361,33 @@
           }
           return response.json();
         })
-        .then(data => {
-          const toolbar = document.getElementById('room-ecology-toolbar');
-          const featureLabels = data.features.map(feature => feature.active === false ? `${feature.label} (dormant)` : feature.label);
-          const traceLabels = data.traceSummary.labels.length > 0 ? data.traceSummary.labels : ['none'];
-          const effectLabels = data.effects && data.effects.length > 0
-            ? data.effects.map(effect => effect.label || effect.type)
-            : ['none'];
+        .then(renderRoomEcology);
+    }
 
-          toolbar.innerHTML = '';
-          setParagraph(toolbar, `Room: ${data.room.row}, ${data.room.col}`);
-          setParagraph(toolbar, `Features: ${featureLabels.join(', ')}`);
-          setParagraph(toolbar, `Systems: ${effectLabels.join(', ')}`);
-          setParagraph(toolbar, `Traces: ${traceLabels.join(', ')}`);
-          if (data.stock && data.stock.length > 0) {
-            setParagraph(toolbar, `Stock: ${data.stock.map(item => `${item.name} ${item.price}g`).join(', ')}`);
+    function renderRoomState(data) {
+      renderRoomEcology(data.room);
+      renderMessages(data.messages || []);
+      renderUserAttributes(data.user || {});
+      renderTick(data.tick || 0);
+    }
+
+    function loadRoomState() {
+      fetch(`/room-state/${row}/${col}`)
+        .then(response => {
+          if (redirectIfDead(response)) {
+            throw new Error('You died');
           }
-          if (data.commands && data.commands.length > 0) {
-            setParagraph(toolbar, `Commands: ${data.commands.join(', ')}`);
+          if (!response.ok) {
+            throw new Error('Room state unavailable');
           }
-          if (data.innAccess && data.innAccess.required) {
-            setParagraph(toolbar, `Inn: ${data.innAccess.paid ? 'paid' : `${data.innAccess.fee}g`}`);
-          }
-          if (data.activeRound) {
-            setParagraph(toolbar, `Dice pool: ${data.activeRound.pool}g, closes in ${data.activeRound.remainingTicks} ticks`);
-          }
-          if (data.event) {
-            setParagraph(toolbar, `Event: ${data.event.title} (${data.event.eventType})`);
-          }
-          const roomDescription = getRoomDescriptionWithoutLocation(data.description, data.room.row, data.room.col);
-          setParagraph(toolbar, `Reset: ${new Date(data.nextResetAt).toUTCString()} ${roomDescription}`);
-          setPresenceParagraph(toolbar, data.presence || []);
-          const isGuild = data.effects && data.effects.some(effect => effect.type === 'guild');
-          document.getElementById('job-controls').style.display = isGuild ? 'flex' : 'none';
+          return response.json();
+        })
+        .then(renderRoomState)
+        .catch(() => {
+          loadRoomEcology();
+          loadMessages();
+          loadUserAttributes();
+          loadTick();
         });
     }
 
@@ -360,10 +396,7 @@
     }
 
     function updateAll() {
-      heartbeatRoom().finally(loadRoomEcology);
-      loadMessages();
-      loadUserAttributes();
-      loadTick();
+      heartbeatRoom().finally(loadRoomState);
     }
 
     function updateTargetHint() {


### PR DESCRIPTION
## Summary

- Moves daily world/event preparation out of normal room and map reads so scheduled pulses own the heavier work.
- Adds a combined room-state endpoint for chat startup so entering a room loads room details, messages, player state, and tick together.
- Keeps NPC room presence visible as event state while stale player presence still expires normally.

## Validation

- `npm test` — 65 passing tests
- `npm run check` — Wrangler deploy dry-run completed successfully
- Local browser check: map event links rendered red, event room loaded, and NPC quick targeting worked from the room toolbar.